### PR TITLE
Win+CapsLock enables/disables Switchy

### DIFF
--- a/Switchy/main.cpp
+++ b/Switchy/main.cpp
@@ -31,83 +31,83 @@ DWORD GetOSVersion() {
 }
 
 LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam) {
-  if (nCode == HC_ACTION) {
-    KBDLLHOOKSTRUCT* p = (KBDLLHOOKSTRUCT*)lParam;
+	if (nCode == HC_ACTION) {
+		KBDLLHOOKSTRUCT* p = (KBDLLHOOKSTRUCT*)lParam;
 
-    if (p->vkCode == VK_LWIN || p->vkCode == VK_RWIN) {
-      if (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN) { winPressed = true; winKeyCode = static_cast<BYTE>(p->vkCode); return 1; }
-      else if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP) {
-        if (enabledSwitched) { winPressed = enabledSwitched = false; return 1; }
-        else if (winPressed) {
-          if (winKeyCode) {
-            UnhookWindowsHookEx(hHook);
-            keybd_event(winKeyCode, 0x3a, 0, 0);
-            keybd_event(winKeyCode, 0x3a, KEYEVENTF_KEYUP, 0);
-            hHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, 0, 0);
-            winKeyCode = 0x00;
-          }
-          winPressed = false;
-        }
-      }
-    }
+		if (p->vkCode == VK_LWIN || p->vkCode == VK_RWIN) {
+			if (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN) { winPressed = true; winKeyCode = static_cast<BYTE>(p->vkCode); return 1; }
+			else if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP) {
+				if (enabledSwitched) { winPressed = enabledSwitched = false; return 1; }
+				else if (winPressed) {
+					if (winKeyCode) {
+						UnhookWindowsHookEx(hHook);
+						keybd_event(winKeyCode, 0x3a, 0, 0);
+						keybd_event(winKeyCode, 0x3a, KEYEVENTF_KEYUP, 0);
+						hHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, 0, 0);
+						winKeyCode = 0x00;
+					}
+					winPressed = false;
+				}
+			}
+		}
 
-    if (p->vkCode == VK_CAPITAL) {
-      if (winPressed) {
-        if (!wasPressed) { if (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN) enabled = !enabled, enabledSwitched = wasPressed = true; }
-        else if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP) wasPressed = false;
+		if (p->vkCode == VK_CAPITAL) {
+			if (winPressed) {
+				if (!wasPressed) { if (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN) enabled = !enabled, enabledSwitched = wasPressed = true; }
+				else if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP) wasPressed = false;
 
-        return 1;
-      }
+				return 1;
+			}
 
-      if (enabled) {
-        if (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN) {
-          if (GetKeyState(VK_LSHIFT) & 0x8000) {
-            UnhookWindowsHookEx(hHook);
-            keybd_event(VK_CAPITAL, 0x3a, 0, 0);
-            keybd_event(VK_CAPITAL, 0x3a, KEYEVENTF_KEYUP, 0);
-            hHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, 0, 0);
-            return 1;
-          }
+			if (enabled) {
+				if (wParam == WM_KEYDOWN || wParam == WM_SYSKEYDOWN) {
+					if (GetKeyState(VK_LSHIFT) & 0x8000) {
+						UnhookWindowsHookEx(hHook);
+						keybd_event(VK_CAPITAL, 0x3a, 0, 0);
+						keybd_event(VK_CAPITAL, 0x3a, KEYEVENTF_KEYUP, 0);
+						hHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, 0, 0);
+						return 1;
+					}
 
-          if (!wasPressed) {
-            wasPressed = true;
+					if (!wasPressed) {
+						wasPressed = true;
 
-            if (popup) {
-              keybd_event(VK_LWIN, 0x3a, 0, 0);
-              keybd_event(VK_SPACE, 0x3a, 0, 0);
-            } else {
-              HWND hWnd = GetForegroundWindow();
-              if (hWnd) {
-                hWnd = GetAncestor(hWnd, GA_ROOTOWNER);
-                PostMessage(hWnd, WM_INPUTLANGCHANGEREQUEST, 0, (LPARAM)HKL_NEXT);
-              }
-            }
-          }
-        }
+						if (popup) {
+							keybd_event(VK_LWIN, 0x3a, 0, 0);
+							keybd_event(VK_SPACE, 0x3a, 0, 0);
+						} else {
+							HWND hWnd = GetForegroundWindow();
+							if (hWnd) {
+								hWnd = GetAncestor(hWnd, GA_ROOTOWNER);
+								PostMessage(hWnd, WM_INPUTLANGCHANGEREQUEST, 0, (LPARAM)HKL_NEXT);
+							}
+						}
+					}
+				}
 
-        if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP) {
-          wasPressed = false;
+				if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP) {
+					wasPressed = false;
 
-          if (popup) {
-            keybd_event(VK_LWIN, 0x3a, KEYEVENTF_KEYUP, 0);
-            keybd_event(VK_SPACE, 0x3a, KEYEVENTF_KEYUP, 0);
-          }
-        }
-        return 1;
-      }
-    }
-    else if (winPressed) {
-      if (winKeyCode) {
-        UnhookWindowsHookEx(hHook);
-        keybd_event(winKeyCode, 0x3a, 0, 0);
-        hHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, 0, 0);
-        winKeyCode = 0x00;
-      }
-      winPressed = false;
-    }
-  }
+					if (popup) {
+						keybd_event(VK_LWIN, 0x3a, KEYEVENTF_KEYUP, 0);
+						keybd_event(VK_SPACE, 0x3a, KEYEVENTF_KEYUP, 0);
+					}
+				}
+				return 1;
+			}
+		}
+		else if (winPressed) {
+			if (winKeyCode) {
+				UnhookWindowsHookEx(hHook);
+				keybd_event(winKeyCode, 0x3a, 0, 0);
+				hHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, 0, 0);
+				winKeyCode = 0x00;
+			}
+			winPressed = false;
+		}
+	}
 
-  return CallNextHookEx(hHook, nCode, wParam, lParam);
+	return CallNextHookEx(hHook, nCode, wParam, lParam);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
I found that in games, when Switchy is on, I can't use CapsLock as my in-game button. Therefore I have added Win+Caps Lock that enables/disables Switchy, so I don't have to kill it through Task Manager every time I enter game that has Caps Lock binding in it.