### PR TITLE
Register Caps+Shift as CapsLock state switch as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Switchy
+# Switchy-mod
 Switches keyboard layout with the Caps Lock key.
 
-Just put [Switchy.exe](https://github.com/erryox/Switchy/releases/latest) in the startup folder (to open it press **Win+R** and type **shell:startup**).  
-If you want to hide the pop-up in Windows 10/11, put in this folder a shortcut with **nopopup** parameter instead of the file itself.
+Just put [Switchy.exe](https://github.com/1280px/Switchy/releases/download/m1.0/Switchy.exe) in the Startup folder (to open it press **Win+R** and type **shell:startup**).
+
+In this mod, the language switcher pop-up is disabled by default; If you want to get it back, for whatever reason, put in this folder a shortcut with **/showpopup** parameter instead of the file itself.
 
 > Note: for keyboard layout switching to work in programs running with administrator privileges, Switchy must also be run with administrator privileges. This can be done using Task Scheduler.
 
 Usage:
 * **CapsLock** to change keyboard layout  
-* **Shift+CapsLock** to toggle CapsLock state
-* **Alt+CapsLock** to enable/disable Switchy
+* **Shift+CapsLock / CapsLock+Shift** to toggle CapsLock state
+* ~~**Alt+CapsLock** to enable/disable Switchy~~

--- a/Switchy/main.c
+++ b/Switchy/main.c
@@ -18,7 +18,6 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam);
 
 
 HHOOK hHook;
-BOOL enabled = TRUE;
 BOOL keystrokeCapsProcessed = FALSE;
 BOOL keystrokeShiftProcessed = FALSE;
 BOOL winPressed = FALSE;
@@ -30,15 +29,15 @@ Settings settings = {
 
 int main(int argc, char** argv)
 {
-	if (argc > 1 && strcmp(argv[1], "nopopup") == 0)
+	if (argc > 1 && strcmp(argv[1], "showpopup") != 0)
 	{
-		settings.popup = FALSE;
+		settings.popup = GetOSVersion() >= 10;
 	}
 	else
 	{
-		settings.popup = GetOSVersion() >= 10;
-		//settings.popup = FALSE;
+		settings.popup = FALSE;
 	}
+
 #if _DEBUG
 	printf("Pop-up is %s\n", settings.popup ? "enabled" : "disabled");
 #endif
@@ -129,15 +128,6 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 #endif // _DEBUG
 		if (key->vkCode == VK_CAPITAL)
 		{
-			if (wParam == WM_SYSKEYDOWN && !keystrokeCapsProcessed)
-			{
-				keystrokeCapsProcessed = TRUE;
-				enabled = !enabled;
-#if _DEBUG
-				printf("Switchy has been %s\n", enabled ? "enabled" : "disabled");
-#endif // _DEBUG
-				return 1;
-			}
 
 			if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP)
 			{
@@ -149,7 +139,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 					ReleaseKey(VK_LWIN);
 				}
 
-				if (enabled && !settings.popup)
+				if (!settings.popup)
 				{
 					if (!keystrokeShiftProcessed) {
 						PressKey(VK_MENU);
@@ -162,11 +152,6 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 						keystrokeShiftProcessed = FALSE;
 					}
 				}
-			}
-
-			if (!enabled)
-			{
-				return CallNextHookEx(hHook, nCode, wParam, lParam);
 			}
 
 			if (wParam == WM_KEYDOWN && !keystrokeCapsProcessed)
@@ -198,11 +183,6 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 			if ((wParam == WM_KEYUP || wParam == WM_SYSKEYUP) && !keystrokeCapsProcessed)
 			{
 				keystrokeShiftProcessed = FALSE;
-			}
-
-			if (!enabled)
-			{
-				return CallNextHookEx(hHook, nCode, wParam, lParam);
 			}
 
 			if (wParam == WM_KEYDOWN && !keystrokeShiftProcessed)

--- a/Switchy/main.c
+++ b/Switchy/main.c
@@ -37,6 +37,7 @@ int main(int argc, char** argv)
 	else
 	{
 		settings.popup = GetOSVersion() >= 10;
+		//settings.popup = FALSE;
 	}
 #if _DEBUG
 	printf("Pop-up is %s\n", settings.popup ? "enabled" : "disabled");
@@ -148,11 +149,18 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 					ReleaseKey(VK_LWIN);
 				}
 
-				if (enabled && !settings.popup) {
-					PressKey(VK_MENU);
-					PressKey(VK_LSHIFT);
-					ReleaseKey(VK_MENU);
-					ReleaseKey(VK_LSHIFT);
+				if (enabled && !settings.popup)
+				{
+					if (!keystrokeShiftProcessed) {
+						PressKey(VK_MENU);
+						PressKey(VK_LSHIFT);
+						ReleaseKey(VK_MENU);
+						ReleaseKey(VK_LSHIFT);
+					}
+					else
+					{
+						keystrokeShiftProcessed = FALSE;
+					}
 				}
 			}
 
@@ -187,7 +195,7 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 		else if (key->vkCode == VK_LSHIFT)
 		{
 
-			if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP)
+			if ((wParam == WM_KEYUP || wParam == WM_SYSKEYUP) && !keystrokeCapsProcessed)
 			{
 				keystrokeShiftProcessed = FALSE;
 			}
@@ -204,10 +212,18 @@ LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
 				if (keystrokeCapsProcessed == TRUE)
 				{
 					ToggleCapsLockState();
-					return 1;
+					if (settings.popup)
+					{
+						PressKey(VK_LWIN);
+						PressKey(VK_SPACE);
+						ReleaseKey(VK_SPACE);
+						winPressed = TRUE;
+					}
+
+					return 0;
 				}
 			}
-			return 1;
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Simple yet somewhat convoluted solution to register both Shift+Caps and Caps+Shift as CapsLock state switch combinations, which makes it more convenient when you type very fast. I troubleshooted as many bugs as I could, but it still may contain a few, though I didn't find any more for now.